### PR TITLE
Fixed some paths.

### DIFF
--- a/sweetconfigs-xorg/dunst/dunstrc
+++ b/sweetconfigs-xorg/dunst/dunstrc
@@ -76,4 +76,4 @@
 
 [logger]
   summary = "*"
-  script = ~/Documents/Test/eww/Widgets-V4/scripts/logger
+  script = $HOME/.config/sweetconfigs-xorg/eww/scripts/logger

--- a/sweetconfigs-xorg/eww/scripts/music
+++ b/sweetconfigs-xorg/eww/scripts/music
@@ -62,7 +62,7 @@ cover_notification () {
 
 cover () {
     cover="$cache/cover.png"
-    fallback="$HOME/Documents/Test/eww/Bar/assets/fallback.png"
+    fallback="$HOME/.config/sweetconfigs-xorg/eww/assets/fallback.png"
 
     [ $(playerctl -p $players metadata mpris:artUrl) ] && curl -s "$albumart" --output $cover || cp $fallback $cover 
     echo $cover


### PR DESCRIPTION
The [dunstrc file](https://github.com/Deathemonic/SweetDots/blob/xorg/sweetconfigs-xorg/dunst/dunstrc) and the [music file](https://github.com/Deathemonic/SweetDots/blob/xorg/sweetconfigs-xorg/eww/scripts/music) had reference to `~/Documents/Test/eww`. Changed those to actual paths. 