### PR TITLE
Fix /bin/bar/status

### DIFF
--- a/sweetconfigs-xorg/bin/bar/status
+++ b/sweetconfigs-xorg/bin/bar/status
@@ -33,12 +33,12 @@ fi
 if [[ "$1" == "scroll-music" ]]; then
     echo $player_status
 else
-    if [ $player_status = "Stopped" ]; then
+    if [ "$player_status" == "Stopped" ]; then
         echo "Offline"
-    elif [ $player_status = "Paused"  ]; then
+    elif [ "$player_status" == "Paused"  ]; then
         update_hooks "$bar_pid" 2
         playerctl -p $players metadata --format '{{ artist }} - {{ title }}'
-    elif [ $player_status = "Offline"  ]; then
+    elif [ "$player_status" == "Offline"  ]; then
         echo $player_status
     else
         update_hooks "$bar_pid" 1


### PR DESCRIPTION
`/bin/bar/status` was throwing and exception due to syntax error in code:
```
No players found
./status: line 36: [: =: unary operator expected
./status: line 38: [: =: unary operator expected
./status: line 41: [: =: unary operator expected
No players found
```
I found this lines and fix errors